### PR TITLE
Support private registries

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "chalk": "^2.4.1",
     "debug": "^3.1.0",
     "fs-extra": "^6.0.1",
-    "http-call": "^5.1.3",
     "semver": "^5.5.0"
   },
   "devDependencies": {

--- a/src/get_version.ts
+++ b/src/get_version.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs-extra'
-import HTTP from 'http-call'
+import {promisify} from 'util'
+const exec = promisify(require('child_process').exec)
 
 async function run(name: string, file: string, version: string) {
   await fs.outputJSON(file, {current: version}) // touch file with current version to prevent multiple updates
-  const {body} = await HTTP.get(`https://registry.npmjs.org/${name.replace('/', '%2f')}`, {timeout: 5000})
-  await fs.outputJSON(file, {...body['dist-tags'], current: version})
+  const {stdout} = await exec(`npm view ${name} dist-tags --json`)
+  const distTags = JSON.parse(stdout)
+  await fs.outputJSON(file, {...distTags, current: version})
   process.exit(0)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,16 +754,6 @@ http-call@^5.1.2:
     is-stream "^1.1.0"
     tunnel-agent "^0.6.0"
 
-http-call@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/http-call/-/http-call-5.1.3.tgz#1864c6588985538fbf97c6ba1b2dbbebb609c459"
-  dependencies:
-    content-type "^1.0.4"
-    debug "^3.1.0"
-    is-retry-allowed "^1.1.0"
-    is-stream "^1.1.0"
-    tunnel-agent "^0.6.0"
-
 hyperlinker@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"


### PR DESCRIPTION
Use npm view to acquire `dist-tags` which will account for private registries, including those requiring auth, set up with [npmrc](https://docs.npmjs.com/files/npmrc) files. Should resolve https://github.com/oclif/plugin-warn-if-update-available/issues/7