### PR TITLE
fix: add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,6 @@
     "postpublish": "yarn run clean",
     "preversion": "yarn run clean",
     "version": "oclif readme && git add README.md"
-  }
+  },
+  "main": "lib/index.js"
 }


### PR DESCRIPTION
### What does this PR do?

Adds the `main` entry to the package.json in order to improve the performance of module resolution in oclif/core
