### PR TITLE
fix: add check for FORCE_VERSION_CACHE_UPDATE env variable

### DIFF
--- a/src/hooks/init/check-update.ts
+++ b/src/hooks/init/check-update.ts
@@ -44,7 +44,7 @@ const hook: Hook<'init'> = async function ({config}) {
   }
 
   const refreshNeeded = async () => {
-    if (process.env.FORCE_VERSION_CACHE_UPDATE) return true
+    if (this.config.scopedEnvVarTrue('FORCE_VERSION_CACHE_UPDATE')) return true
     try {
       const {mtime} = await fs.stat(file)
       const staleAt = new Date(mtime.valueOf() + (1000 * 60 * 60 * 24 * timeoutInDays))

--- a/src/hooks/init/check-update.ts
+++ b/src/hooks/init/check-update.ts
@@ -44,6 +44,7 @@ const hook: Hook<'init'> = async function ({config}) {
   }
 
   const refreshNeeded = async () => {
+    if (process.env.FORCE_VERSION_CACHE_UPDATE) return true
     try {
       const {mtime} = await fs.stat(file)
       const staleAt = new Date(mtime.valueOf() + (1000 * 60 * 60 * 24 * timeoutInDays))


### PR DESCRIPTION
Adds a check for a FORCE_VERSION_CACHE_UPDATE environment variable in order to force a cache refresh.

Would allow for a solution to a [bug on the Heroku CLI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001M8kGoYAJ/view).