### PR TITLE
fix: default npm registry to config.npmRegistry

### DIFF
--- a/src/hooks/init/check-update.ts
+++ b/src/hooks/init/check-update.ts
@@ -124,7 +124,7 @@ export async function getNewerVersion({
     return distTags[tag]
 }
 
-const hook: Hook<'init'> = async function ({config}) {
+const hook: Hook.Init = async function ({config}) {
   const debug = makeDebug('update-check')
   const versionFile = join(config.cacheDir, 'version')
   const lastWarningFile = join(config.cacheDir, 'last-warning')
@@ -133,7 +133,7 @@ const hook: Hook<'init'> = async function ({config}) {
   const {
     authorization = '',
     message = '<%= config.name %> update available from <%= chalk.greenBright(config.version) %> to <%= chalk.greenBright(latest) %>.',
-    registry = 'https://registry.npmjs.org',
+    registry = this.config.npmRegistry ?? 'https://registry.npmjs.org',
     timeoutInDays = 60,
   } = config.pjson.oclif['warn-if-update-available'] ?? {}
 

--- a/src/hooks/init/check-update.ts
+++ b/src/hooks/init/check-update.ts
@@ -133,7 +133,7 @@ const hook: Hook.Init = async function ({config}) {
   const {
     authorization = '',
     message = '<%= config.name %> update available from <%= chalk.greenBright(config.version) %> to <%= chalk.greenBright(latest) %>.',
-    registry = this.config.npmRegistry ?? 'https://registry.npmjs.org',
+    registry = config.npmRegistry ?? 'https://registry.npmjs.org',
     timeoutInDays = 60,
   } = config.pjson.oclif['warn-if-update-available'] ?? {}
 


### PR DESCRIPTION
Default npm registry to `this.config.npmRegistry` so that we don't have to mutate the pjson after creating `Config`: https://github.com/salesforcecli/cli/blob/main/src/cli.ts#L44