### PR TITLE
fix: use lodash instead of lodash.template

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "chalk": "^5.3.0",
     "debug": "^4.1.0",
     "http-call": "^5.2.2",
-    "lodash.template": "^4.5.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^18",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@oclif/test": "^3.2.13",
     "@types/chai": "^4.3.11",
     "@types/debug": "^4.1.12",
-    "@types/lodash.template": "^4.5.3",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18",
     "chai": "^4.4.0",

--- a/src/hooks/init/check-update.ts
+++ b/src/hooks/init/check-update.ts
@@ -164,14 +164,14 @@ const hook: Hook.Init = async function ({config}) {
     const newerVersion = await getNewerVersion({argv: process.argv, config, lastWarningFile, versionFile})
     if (newerVersion) {
       // Default message if the user doesn't provide one
-      const [template] = await Promise.all([
-        import('lodash.template'),
+      const [lodash] = await Promise.all([
+        import('lodash'),
         // Update the modified time (mtime) of the last-warning file so that we can track the last time we
         // showed the warning. This makes it possible to respect the frequency and frequencyUnit options.
         writeFile(lastWarningFile, ''),
       ])
       this.warn(
-        template.default(message)({
+        lodash.template(message)({
           chalk,
           config,
           latest: newerVersion,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,13 +2133,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash.template@^4.5.3":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@types/lodash.template/-/lodash.template-4.5.3.tgz#1174483eaa761a76a9d68c4adbee4c4e2742f329"
-  integrity sha512-Mo0UYKLu1oXgkV9TVoXZLlXXjyIXlW7ZQRxi/4gQJmzJr63dmicE8gG0OkPjYTKBrBic852q0JzqrtNUWLBIyA==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash@*":
   version "4.14.197"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.197.tgz#e95c5ddcc814ec3e84c891910a01e0c8a378c54b"


### PR DESCRIPTION
Use `lodash` instead of `lodash.template` to fix security vulnerability.

Context: lodash no longer recommends per-method packages: https://lodash.com/per-method-packages

Fixes #589 
@W-15692116@