### PR TITLE
Suggestion: follow the user's npmrc config by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This plugin shows a warning message if a user is running an out of date CLI.
 
 # How it works
 
-This checks the version against the npm registry asynchronously in a forked process once every 60 days by default (see [Configuration](#configuration) for how to configure this). It then saves a version file to the cache directory that will enable the warning. The upside of this method is that it won't block a user while they're using your CLI—the downside is that it will only display _after_ running a command that fetches the new version.
+This checks the version against the npm registry asynchronously in a forked process once every 7 days by default (see [Configuration](#configuration) for how to configure this). It then saves a version file to the cache directory that will enable the warning. The upside of this method is that it won't block a user while they're using your CLI—the downside is that it will only display _after_ running a command that fetches the new version.
 
 # Installation
 
@@ -49,8 +49,8 @@ any of the following configuration properties:
 
 - `timeoutInDays` - Duration between update checks. Defaults to 60.
 - `message` - Customize update message.
-- `registry` - URL of registry. Defaults to the public npm registry: `https://registry.npmjs.org`
-- `authorization` - Authorization header value for registries that require auth.
+- `registry` - URL of registry. Defaults to following your .npmrc configuration
+- `authorization` - Authorization header value for registries that require auth. Defaults to following your .npmrc configuration
 - `frequency` - The frequency that the new version warning should be shown.
 - `frequencyUnit` - The unit of time that should be used to calculate the frequency (`days`, `hours`, `minutes`, `seconds`, `milliseconds`). Defaults to `minutes`.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This plugin shows a warning message if a user is running an out of date CLI.
 
 # How it works
 
-This checks the version against the npm registry asynchronously in a forked process once every 7 days by default (see [Configuration](#configuration) for how to configure this). It then saves a version file to the cache directory that will enable the warning. The upside of this method is that it won't block a user while they're using your CLI—the downside is that it will only display _after_ running a command that fetches the new version.
+This checks the version against the npm registry asynchronously in a forked process once every 60 days by default (see [Configuration](#configuration) for how to configure this). It then saves a version file to the cache directory that will enable the warning. The upside of this method is that it won't block a user while they're using your CLI—the downside is that it will only display _after_ running a command that fetches the new version.
 
 # Installation
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "ansis": "^3.3.1",
     "debug": "^4.3.5",
     "http-call": "^5.2.2",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "registry-auth-token": "^5.0.2"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^19",

--- a/src/get-version.ts
+++ b/src/get-version.ts
@@ -9,16 +9,16 @@ async function run([name, file, version, registry, authorization]: string[]) {
   debug('file:', file)
   debug('version:', version)
   debug('registry:', registry)
-  debug('authorization:', authorization)
+
   const url = [
     registry.replace(/\/+$/, ''), // remove trailing slash
     name.replace('/', '%2f'), // scoped packages need escaped separator
   ].join('/')
   const headers = authorization ? {authorization} : {}
   await mkdir(dirname(file), {recursive: true})
-  await writeFile(file, JSON.stringify({current: version, headers})) // touch file with current version to prevent multiple updates
+  await writeFile(file, JSON.stringify({current: version})) // touch file with current version to prevent multiple updates
   const {body} = await HTTP.get<{'dist-tags': string[]}>(url, {headers, timeout: 5000})
-  await writeFile(file, JSON.stringify({...body['dist-tags'], authorization, current: version}))
+  await writeFile(file, JSON.stringify({...body['dist-tags'], current: version}))
   // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit
   process.exit(0)
 }

--- a/src/hooks/init/check-update.ts
+++ b/src/hooks/init/check-update.ts
@@ -139,7 +139,7 @@ const hook: Hook.Init = async function ({config}) {
   const {
     message = '<%= config.name %> update available from <%= chalk.greenBright(config.version) %> to <%= chalk.greenBright(latest) %>.',
     registry = config.npmRegistry ?? getRegistryUrl(scope), // Use custom registry or fallback to 1) registry set for the scope, 2) default registry in the npmrc, or 3) the default registry
-    timeoutInDays = 7,
+    timeoutInDays = 60,
   } = config.pjson.oclif['warn-if-update-available'] ?? {}
 
   // Get the authorization header next as we need the registry to be computed first


### PR DESCRIPTION
Looks up the registry url and authorization details from the npmrc file if they are not included in the config. Hardcoding registries and tokens in the config is not desirable if it can be avoided. Also drops tokens from logs / files to reduce the risk of leaking.